### PR TITLE
Nawhals 1.31.0

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,0 @@
-bot: {automerge: true, inspection: hint-all}
-conda_build: {error_overlinking: true}
-conda_forge_output_validation: true
-github: {branch_name: main, tooling_branch_name: main}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  skip: True  #[py<38]
 
 requirements:
   host:
@@ -31,8 +32,8 @@ test:
     - python
 
 about:
-  home: https://marcogorelli.github.io/narwhals/
-  dev_url: https://github.com/MarcoGorelli/narwhals
+  home: https://github.com/narwhals-dev/narwhals
+  dev_url: https://github.com/narwhals-dev/narwhals
   summary: Extremely lightweight compatibility layer between pandas, Polars, cuDF, and Modin
   license: MIT
   license_file: LICENSE.md
@@ -41,7 +42,7 @@ about:
     Narwhals is an extremely lightweight compatibility layer between pandas, Polars, cuDF, and Modin.
     It allows you to write code that works with all of these libraries without having to worry about
     the differences between them.
-  doc_url: https://marcogorelli.github.io/narwhals/
+  doc_url: https://narwhals-dev.github.io/narwhals/
 
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,12 @@ requirements:
     - pip
   run:
     - python
+  run_constrained:
+    - pandas >=0.25.3
+    - polars >=0.20.3
+    - pyarrow >=11.0.0
+    - pyspark >=3.5.0
+    - dask >=2024.8
 
 test:
   imports:
@@ -29,7 +35,6 @@ test:
     - pip check
   requires:
     - pip
-    - python
 
 about:
   home: https://github.com/narwhals-dev/narwhals

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 333472e2562343dfdd27407ec9b5114a07c81d0416794e4ac6b703dd925c6a1a
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
+    - python
 
 test:
   imports:
@@ -29,7 +28,7 @@ test:
     - pip check
   requires:
     - pip
-    - python {{ python_min }}
+    - python
 
 about:
   home: https://marcogorelli.github.io/narwhals/
@@ -37,6 +36,13 @@ about:
   summary: Extremely lightweight compatibility layer between pandas, Polars, cuDF, and Modin
   license: MIT
   license_file: LICENSE.md
+  license_family: MIT
+  description: |
+    Narwhals is an extremely lightweight compatibility layer between pandas, Polars, cuDF, and Modin.
+    It allows you to write code that works with all of these libraries without having to worry about
+    the differences between them.
+  doc_url: https://marcogorelli.github.io/narwhals/
+
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆ Nawhals 1.31.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7409) 
[Upstream](https://github.com/narwhals-dev/narwhals)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section